### PR TITLE
feat: colorize only ttys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/goccy/go-yaml v1.8.2
 	github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
+	github.com/mattn/go-isatty v0.0.11
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 )


### PR DESCRIPTION
Usually kubectl is also used in aliases such as the ones
available as zsh plugins
(https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/kubectl/kubectl.plugin.zsh).

Unfortunately if you alias k to kubecolor, you won't be able
to get commands such as `kcn` to work because the output in
the subshell will be colorized as well.

This commit checks whether the user is running the command
in a TTY, and returns the colorized version only in this case,
so that kubecolor and kubectl subshell commands can coexist.

---

Example:
![20201011_12h28m16s_grim](https://user-images.githubusercontent.com/4939519/95676289-4f2ce980-0bbd-11eb-800b-65e633ae979d.png)
