### PR TITLE
feat: support kubectl exec

### DIFF
--- a/command/runner.go
+++ b/command/runner.go
@@ -31,9 +31,15 @@ func Run(args []string, kubeColorDebug bool) error {
 	fd := os.Stdout.Fd()
 	colorize := isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd) || kubeColorDebug
 
+	subcommandInfo, ok := kubectl.InspectSubcommandInfo(args)
+	if !ok {
+		colorize = false
+	}
+
 	if !colorize {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
 	}
 
 	if err = cmd.Start(); err != nil {
@@ -44,8 +50,6 @@ func Run(args []string, kubeColorDebug bool) error {
 		cmd.Wait()
 		return nil
 	}
-
-	subcommandInfo, ok := kubectl.InspectSubcommandInfo(args)
 
 	wg := &sync.WaitGroup{}
 

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -25,6 +25,7 @@ type Subcommand int
 const (
 	Get Subcommand = iota + 1
 	Top
+	Exec
 	Describe
 )
 
@@ -34,6 +35,8 @@ func InspectSubcommand(command string) (Subcommand, bool) {
 		return Get, true
 	case "describe":
 		return Describe, true
+	case "exec":
+		return Exec, false
 	case "top":
 		return Top, true
 


### PR DESCRIPTION
This PR adds support for `kubectl exec` so that one can still execute commands in a pod :+1: 

This will also switch the default output to be non-colorized if the command is not recognized