### PR TITLE
use go-colorable for windows

### DIFF
--- a/cmd/kubecolor/main.go
+++ b/cmd/kubecolor/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	err := command.Run(os.Args[1:], false)
+	err := command.Run(os.Args[1:])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, err.Error())
 		os.Exit(1)

--- a/command/runner.go
+++ b/command/runner.go
@@ -15,7 +15,7 @@ var (
 	stderr = colorable.NewColorableStderr()
 )
 
-func Run(args []string, disableColor bool) error {
+func Run(args []string) error {
 	args, plainFlagFound := removePlainFlagIfExists(args)
 	args, lightBackgroundFlagFound := removeLightBackgroundFlagIfExists(args)
 	darkBackground := !lightBackgroundFlagFound
@@ -32,7 +32,8 @@ func Run(args []string, disableColor bool) error {
 		return err
 	}
 
-	if disableColor {
+	// --plain
+	if plainFlagFound {
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
 	}
@@ -41,7 +42,7 @@ func Run(args []string, disableColor bool) error {
 		return err
 	}
 
-	if disableColor {
+	if plainFlagFound {
 		cmd.Wait()
 		return nil
 	}
@@ -51,11 +52,6 @@ func Run(args []string, disableColor bool) error {
 	wg := &sync.WaitGroup{}
 
 	switch {
-	case plainFlagFound: // --plain
-		runAsync(wg, []func(){
-			func() { printer.PrintPlain(outReader, stdout) },
-			func() { printer.PrintPlain(errReader, stderr) },
-		})
 	case subcommandInfo.Help:
 		runAsync(wg, []func(){
 			func() { printer.PrintWithColor(outReader, stdout, color.Yellow) },

--- a/command/runner.go
+++ b/command/runner.go
@@ -15,7 +15,7 @@ var (
 	stderr = colorable.NewColorableStderr()
 )
 
-func Run(args []string, kubeColorDebug bool) error {
+func Run(args []string, disableColor bool) error {
 	args, plainFlagFound := removePlainFlagIfExists(args)
 	args, lightBackgroundFlagFound := removeLightBackgroundFlagIfExists(args)
 	darkBackground := !lightBackgroundFlagFound
@@ -32,9 +32,7 @@ func Run(args []string, kubeColorDebug bool) error {
 		return err
 	}
 
-	colorize := kubeColorDebug
-
-	if !colorize {
+	if disableColor {
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
 	}
@@ -43,7 +41,7 @@ func Run(args []string, kubeColorDebug bool) error {
 		return err
 	}
 
-	if !colorize {
+	if disableColor {
 		cmd.Wait()
 		return nil
 	}

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -84,7 +84,7 @@ func getKubecolorOutput(args []string) string {
 	os.Stdout = w
 	os.Stderr = w
 
-	err = command.Run(args, false)
+	err = command.Run(args)
 	if err != nil {
 		panic(err)
 	}

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -84,7 +84,7 @@ func getKubecolorOutput(args []string) string {
 	os.Stdout = w
 	os.Stderr = w
 
-	err = command.Run(args, true)
+	err = command.Run(args, false)
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.14
 
 require (
 	github.com/google/go-cmp v0.5.2
-	github.com/mattn/go-isatty v0.0.12
-	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 // indirect
+	github.com/mattn/go-colorable v0.1.8
+	golang.org/x/sys v0.0.0-20201013081832-0aaa2718063a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,12 @@
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
+github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 h1:bNEHhJCnrwMKNMmOx3yAynp5vs5/gRy+XWFtZFu7NBM=
-golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201013081832-0aaa2718063a h1:bhXnJ7fn2SiL+C8iOWPfNBJKDTjUByftpPW7b9CX94U=
+golang.org/x/sys v0.0.0-20201013081832-0aaa2718063a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
the go-colorable package is possible to handle escape sequence for ansi color on windows.
see: https://github.com/mattn/go-colorable/tree/v0.1.8

Basically, it adds color. Even the pipe will be given the results with the color on it. If we want to disable color, use `--plain` (already exists) flag