### PR TITLE
Simplify code and get it work when exec/edit

### DIFF
--- a/command/runner.go
+++ b/command/runner.go
@@ -28,6 +28,11 @@ func Run(args []string) error {
 	// when the given subcommand is supported AND --plain is NOT specified, then we colorize it
 	shouldColorize := subcommandFound && isColoringSupported(subcommandInfo.Subcommand) && !plainFlagFound
 
+	// when it is for Help, we exceptionally colorize it in Help color
+	if subcommandInfo.Help {
+		shouldColorize = true
+	}
+
 	cmd := exec.Command("kubectl", args...)
 	cmd.Stdin = os.Stdin
 

--- a/command/runner.go
+++ b/command/runner.go
@@ -22,22 +22,31 @@ func Run(args []string) error {
 	args, lightBackgroundFlagFound := removeLightBackgroundFlagIfExists(args)
 	darkBackground := !lightBackgroundFlagFound
 
+	// subcommandFound becomes false when subcommand is not found; e.g. "kubecolor --help"
+	subcommandInfo, subcommandFound := kubectl.InspectSubcommandInfo(args)
+
+	// when the given subcommand is supported AND --plain is NOT specified, then we colorize it
+	shouldColorize := subcommandFound && isColoringSupported(subcommandInfo.Subcommand) && !plainFlagFound
+
 	cmd := exec.Command("kubectl", args...)
-
-	outReader, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-
-	errReader, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-
 	cmd.Stdin = os.Stdin
 
-	// --plain
-	if plainFlagFound {
+	var outReader, errReader io.Reader
+	var err error
+
+	if shouldColorize {
+		outReader, err = cmd.StdoutPipe()
+		if err != nil {
+			return err
+		}
+
+		errReader, err = cmd.StderrPipe()
+		if err != nil {
+			return err
+		}
+	} else {
+		// when we don't colorize the output,
+		// we don't need to capthre it so just set stdout/err here
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
 	}
@@ -46,36 +55,22 @@ func Run(args []string) error {
 		return err
 	}
 
-	if plainFlagFound {
+	if !shouldColorize {
 		cmd.Wait()
 		return nil
 	}
 
-	subcommandInfo, ok := kubectl.InspectSubcommandInfo(args)
-
 	wg := &sync.WaitGroup{}
 
-	switch {
-	case subcommandInfo.Help:
+	if subcommandInfo.Help {
 		runAsync(wg, []func(){
 			func() { printer.PrintWithColor(outReader, stdout, color.Yellow) },
 			func() { printer.PrintErrorOrWarning(errReader, stderr) },
 		})
-	case !ok:
-		// given subcommand is not supported to colorize
-		// so just print it in green
+
+	} else {
 		runAsync(wg, []func(){
-			func() { printer.PrintWithColor(outReader, stdout, color.Green) },
-			func() { printer.PrintErrorOrWarning(errReader, stderr) },
-		})
-	case subcommandInfo.Subcommand == kubectl.Exec:
-		runAsync(wg, []func(){
-			func() { io.Copy(stdout, outReader) },
-			func() { printer.PrintErrorOrWarning(errReader, stderr) },
-		})
-	default:
-		runAsync(wg, []func(){
-			func() { printer.Print(outReader, stdout, subcommandInfo, darkBackground) }, // TODO fix to enable configuration for light background
+			func() { printer.Print(outReader, stdout, subcommandInfo, darkBackground) },
 			func() { printer.PrintErrorOrWarning(errReader, stderr) },
 		})
 	}
@@ -115,4 +110,28 @@ func removeLightBackgroundFlagIfExists(args []string) ([]string, bool) {
 	}
 
 	return args, false
+}
+
+func isColoringSupported(sc kubectl.Subcommand) bool {
+	// when you add something here, it won't be colorized
+	unsupported := []kubectl.Subcommand{
+		kubectl.Create,
+		kubectl.Delete,
+		kubectl.Edit,
+		kubectl.Attach,
+		kubectl.Replace,
+		kubectl.Completion,
+		kubectl.Exec,
+		kubectl.Proxy,
+		kubectl.Plugin,
+		kubectl.Wait,
+	}
+
+	for _, u := range unsupported {
+		if sc == u {
+			return false
+		}
+	}
+
+	return true
 }

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.14
 require (
 	github.com/google/go-cmp v0.5.2
 	github.com/mattn/go-colorable v0.1.8
-	golang.org/x/sys v0.0.0-20201013081832-0aaa2718063a // indirect
+	golang.org/x/sys v0.0.0-20201013132646-2da7054afaeb // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201013081832-0aaa2718063a h1:bhXnJ7fn2SiL+C8iOWPfNBJKDTjUByftpPW7b9CX94U=
 golang.org/x/sys v0.0.0-20201013081832-0aaa2718063a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201013132646-2da7054afaeb h1:HS9IzC4UFbpMBLQUDSQcU+ViVT1vdFCQVjdPVpTlZrs=
+golang.org/x/sys v0.0.0-20201013132646-2da7054afaeb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -24,29 +24,97 @@ const (
 type Subcommand int
 
 const (
-	Get Subcommand = iota + 1
+	Create Subcommand = iota + 1
+	Expose
+	Run
+	Set
+	Explain
+	Get
+	Edit
+	Delete
+	Rollout
+	Scale
+	Autoscale
+	Certificate
+	ClusterInfo
 	Top
+	Cordon
+	Uncordon
+	Drain
+	Taint
 	Describe
-	APIResources
+	Logs
+	Attach
 	Exec
+	PortForward
+	Proxy
+	Cp
+	Auth
+	Diff
+	Apply
+	Patch
+	Replace
+	Wait
+	Convert
+	Kustomize
+	Label
+	Annotate
+	Completion
+	APIResources
+	APIVersions
+	Config
+	Plugin
+	Version
 )
 
-func InspectSubcommand(command string) (Subcommand, bool) {
-	switch command {
-	case "get":
-		return Get, true
-	case "describe":
-		return Describe, true
-	case "top":
-		return Top, true
-	case "api-resources":
-		return APIResources, true
-	case "exec":
-		return Exec, true
+var strToSubcommand = map[string]Subcommand{
+	"create":        Create,
+	"expose":        Expose,
+	"run":           Run,
+	"set":           Set,
+	"explain":       Explain,
+	"get":           Get,
+	"edit":          Edit,
+	"delete":        Delete,
+	"rollout":       Rollout,
+	"scale":         Scale,
+	"autoscale":     Autoscale,
+	"certificate":   Certificate,
+	"cluster-info":  ClusterInfo,
+	"top":           Top,
+	"cordon":        Cordon,
+	"uncordon":      Uncordon,
+	"drain":         Drain,
+	"taint":         Taint,
+	"describe":      Describe,
+	"logs":          Logs,
+	"attach":        Attach,
+	"exec":          Exec,
+	"port-forward":  PortForward,
+	"proxy":         Proxy,
+	"cp":            Cp,
+	"auth":          Auth,
+	"diff":          Diff,
+	"apply":         Apply,
+	"patch":         Patch,
+	"replace":       Replace,
+	"wait":          Wait,
+	"convert":       Convert,
+	"kustomize":     Kustomize,
+	"label":         Label,
+	"annotate":      Annotate,
+	"completion":    Completion,
+	"api-resources": APIResources,
+	"api-versions":  APIVersions,
+	"config":        Config,
+	"plugin":        Plugin,
+	"version":       Version,
+}
 
-	default:
-		return Subcommand(0), false
-	}
+func InspectSubcommand(command string) (Subcommand, bool) {
+	sc, ok := strToSubcommand[command]
+
+	return sc, ok
 }
 
 func CollectCommandlineOptions(args []string, info *SubcommandInfo) {

--- a/kubectl/subcommand_test.go
+++ b/kubectl/subcommand_test.go
@@ -40,8 +40,9 @@ func TestInspectSubcommandInfo(t *testing.T) {
 		{"top pod", &SubcommandInfo{Subcommand: Top}, true},
 		{"top pods", &SubcommandInfo{Subcommand: Top}, true},
 
+		{"apply", &SubcommandInfo{Subcommand: Apply}, true},
+
 		{"", &SubcommandInfo{}, false},
-		{"apply", &SubcommandInfo{}, false},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -81,7 +81,7 @@ func Print(r io.Reader, w io.Writer, subcommandInfo *kubectl.SubcommandInfo, dar
 		printer.Print(r)
 
 	default:
-		PrintPlain(r, w)
+		PrintWithColor(r, w, color.Green)
 	}
 }
 


### PR DESCRIPTION
By declaring explicitly which commands are unsupported explicitly, make it easy to understand what will happen when unsupported command is specified.