### PR TITLE
enable to specify which command to use as kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ complete -o default -F __start_kubectl k
 
 Please also refer to [kubectl official doc](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-autocomplete).
 
+### Specify what command to execute as kubectl
+
+Sometimes, you may want to specify what to command to use as `kubectl`. For example,
+when you want to use a versioned-kubectl `kubectl.1.17`, you can do that by an environment variable:
+
+```shell
+KUBECTL_COMMAND="kubectl.1.17" kubecolor get po
+```
+
+When you don't set `KUBECTL_COMMAND`, then `kubectl` is used by default.
 
 ## Supported commands
 

--- a/command/runner.go
+++ b/command/runner.go
@@ -33,7 +33,11 @@ func Run(args []string) error {
 		shouldColorize = true
 	}
 
-	cmd := exec.Command("kubectl", args...)
+	kubectlCmd := "kubectl"
+	if kc := os.Getenv("KUBECTL_COMMAND"); kc != "" {
+		kubectlCmd = kc
+	}
+	cmd := exec.Command(kubectlCmd, args...)
 	cmd.Stdin = os.Stdin
 
 	var outReader, errReader io.Reader


### PR DESCRIPTION
Enable to specify which command to use as kubectl by setting `KUBECTL_COMMAND` env var.