### PR TITLE
treat table in kubectl describe

### DIFF
--- a/printer/kubectl_describe.go
+++ b/printer/kubectl_describe.go
@@ -12,6 +12,7 @@ import (
 // DescribePrinter is a specific printer to print kubectl describe format.
 type DescribePrinter struct {
 	DarkBackground bool
+	TablePrinter   *TablePrinter
 }
 
 func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
@@ -58,6 +59,12 @@ func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
 			spacesIndices = spacesIndices[1:]
 		}
 
+		// when there are multiple columns, treat is as table format
+		if len(columns) > 2 {
+			dp.TablePrinter.printLineAsTableFormat(w, line, getColorsByBackground(dp.DarkBackground))
+			continue
+		}
+
 		// First, write the first value assuming it's a key
 		keyColor := getColorByKeyIndent(indentCnt, basicIndentWidth, dp.DarkBackground)
 		valColor := getColorByValueType(columns[0], dp.DarkBackground)
@@ -75,28 +82,8 @@ func (dp *DescribePrinter) Print(r io.Reader, w io.Writer) {
 			continue
 		}
 
-		// Then, write values
-		// In this for loop, we write spaces and a value
-		// For example, if the line looked like:
-		// e.g.--------------------------------------
-		//     Key:<- spaces1 ->Value1<- spaces2 ->Value2<- spaces3 ->Value3
-		// ------------------------------------------
-		// In each loop, we write spaces+value
-		// So, each iteration will look like
-		// when i == 0 then continue // because indent and key is already written
-		// when i == 1 then Write spaces1 and Value1
-		// when i == 2 then Write spaces2 and Value1
-		// when i == 3 then Write spaces3 and Value1
-		for i, column := range columns {
-			if i == 0 {
-				continue
-			}
-
-			spacesPos := spacesIndices[i-1]
-			spacesCnt := spacesPos[1] - spacesPos[0]
-			fmt.Fprintf(w, "%s%s", toSpaces(spacesCnt), color.Apply(column, getColorByValueType(column, dp.DarkBackground)))
-		}
-
-		fmt.Fprint(w, "\n")
+		spacesPos := spacesIndices[0]
+		spacesCnt := spacesPos[1] - spacesPos[0]
+		fmt.Fprintf(w, "%s%s\n", toSpaces(spacesCnt), color.Apply(columns[1], getColorByValueType(columns[1], dp.DarkBackground)))
 	}
 }

--- a/printer/kubectl_describe_test.go
+++ b/printer/kubectl_describe_test.go
@@ -12,12 +12,14 @@ func Test_DescribePrinter_Print(t *testing.T) {
 	tests := []struct {
 		name           string
 		darkBackground bool
+		tablePrinter   *TablePrinter
 		input          string
 		expected       string
 	}{
 		{
 			name:           "values can be colored by its type",
 			darkBackground: true,
+			tablePrinter:   nil,
 			input: testutil.NewHereDoc(`
 				Name:         nginx-lpv5x
 				Namespace:    default
@@ -41,6 +43,7 @@ func Test_DescribePrinter_Print(t *testing.T) {
 		{
 			name:           "key color changes based on its indentation",
 			darkBackground: true,
+			tablePrinter:   nil,
 			input: testutil.NewHereDoc(`
 				IP:           172.18.0.7
 				IPs:
@@ -61,6 +64,78 @@ func Test_DescribePrinter_Print(t *testing.T) {
 				      [37mStarted[0m:      [36mSat, 10 Oct 2020 14:07:44 +0900[0m
 			`),
 		},
+		{
+			name:           "table format in kubectl describe can be colored by describe",
+			darkBackground: true,
+			tablePrinter:   NewTablePrinter(false, true, nil),
+			input: testutil.NewHereDoc(`
+				Conditions:
+				  Type             Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
+				  ----             ------  -----------------                 ------------------                ------                       -------
+				  MemoryPressure   False   Sun, 18 Oct 2020 12:00:54 +0900   Wed, 14 Oct 2020 09:28:18 +0900   KubeletHasSufficientMemory   kubelet has sufficient memory available
+				  DiskPressure     False   Sun, 18 Oct 2020 12:00:54 +0900   Wed, 14 Oct 2020 09:28:18 +0900   KubeletHasNoDiskPressure     kubelet has no disk pressure
+				Addresses:
+				  InternalIP:  172.17.0.3
+				  Hostname:    minikube
+				Capacity:
+				  cpu:                6
+				  memory:             2036900Ki
+				  pods:               110
+				Allocatable:
+				  cpu:                6
+				  memory:             2036900Ki
+				  pods:               110
+				System Info:
+				  Machine ID:                 55d2ccaefc9847c9a69356e7f3bd23f4
+				  System UUID:                fe312784-2364-4bba-a55e-f56051539c21
+				Non-terminated Pods:          (14 in total)
+				  Namespace                   Name                                CPU Requests  CPU Limits  Memory Requests  Memory Limits  AGE
+				  ---------                   ----                                ------------  ----------  ---------------  -------------  ---
+				  default                     nginx-6799fc88d8-dnmv5              0 (0%)        0 (0%)      0 (0%)           0 (0%)         7d21h
+				  default                     nginx-6799fc88d8-m8pbc              0 (0%)        0 (0%)      0 (0%)           0 (0%)         7d21h
+				  default                     nginx-6799fc88d8-qdf9b              0 (0%)        0 (0%)      0 (0%)           0 (0%)         7d21h
+				Allocated resources:
+				  (Total limits may be over 100 percent, i.e., overcommitted.)
+				  Resource           Requests    Limits
+				  --------           --------    ------
+				  cpu                650m (10%)  0 (0%)
+				  memory             70Mi (3%)   170Mi (8%)
+				Events:              <none>`),
+			expected: testutil.NewHereDoc(`
+				[33mConditions[0m:
+				[36m[0m  [32mType[0m             [35mStatus[0m  [37mLastHeartbeatTime[0m                 [33mLastTransitionTime[0m                [36mReason[0m                       [32mMessage[0m
+				[36m[0m  [32m----[0m             [35m------[0m  [37m-----------------[0m                 [33m------------------[0m                [36m------[0m                       [32m-------[0m
+				[36m[0m  [32mMemoryPressure[0m   [35mFalse[0m   [37mSun, 18 Oct 2020 12:00:54 +0900[0m   [33mWed, 14 Oct 2020 09:28:18 +0900[0m   [36mKubeletHasSufficientMemory[0m   [32mkubelet has sufficient memory available[0m
+				[36m[0m  [32mDiskPressure[0m     [35mFalse[0m   [37mSun, 18 Oct 2020 12:00:54 +0900[0m   [33mWed, 14 Oct 2020 09:28:18 +0900[0m   [36mKubeletHasNoDiskPressure[0m     [32mkubelet has no disk pressure[0m
+				[33mAddresses[0m:
+				  [37mInternalIP[0m:  [36m172.17.0.3[0m
+				  [37mHostname[0m:    [36mminikube[0m
+				[33mCapacity[0m:
+				  [37mcpu[0m:                [35m6[0m
+				  [37mmemory[0m:             [36m2036900Ki[0m
+				  [37mpods[0m:               [35m110[0m
+				[33mAllocatable[0m:
+				  [37mcpu[0m:                [35m6[0m
+				  [37mmemory[0m:             [36m2036900Ki[0m
+				  [37mpods[0m:               [35m110[0m
+				[33mSystem Info[0m:
+				  [37mMachine ID[0m:                 [36m55d2ccaefc9847c9a69356e7f3bd23f4[0m
+				  [37mSystem UUID[0m:                [36mfe312784-2364-4bba-a55e-f56051539c21[0m
+				[33mNon-terminated Pods[0m:          [36m(14 in total)[0m
+				[36m[0m  [32mNamespace[0m                   [35mName[0m                                [37mCPU Requests[0m  [33mCPU Limits[0m  [36mMemory Requests[0m  [32mMemory Limits[0m  [32mAGE[0m
+				[36m[0m  [32m---------[0m                   [35m----[0m                                [37m------------[0m  [33m----------[0m  [36m---------------[0m  [32m-------------[0m  [32m---[0m
+				[36m[0m  [32mdefault[0m                     [35mnginx-6799fc88d8-dnmv5[0m              [37m0 (0%)[0m        [33m0 (0%)[0m      [36m0 (0%)[0m           [32m0 (0%)[0m         [32m7d21h[0m
+				[36m[0m  [32mdefault[0m                     [35mnginx-6799fc88d8-m8pbc[0m              [37m0 (0%)[0m        [33m0 (0%)[0m      [36m0 (0%)[0m           [32m0 (0%)[0m         [32m7d21h[0m
+				[36m[0m  [32mdefault[0m                     [35mnginx-6799fc88d8-qdf9b[0m              [37m0 (0%)[0m        [33m0 (0%)[0m      [36m0 (0%)[0m           [32m0 (0%)[0m         [32m7d21h[0m
+				[33mAllocated resources[0m:
+				  [36m(Total limits may be over 100 percent, i.e., overcommitted.)[0m
+				[36m[0m  [32mResource[0m           [35mRequests[0m    [37mLimits[0m
+				[36m[0m  [32m--------[0m           [35m--------[0m    [37m------[0m
+				[36m[0m  [32mcpu[0m                [35m650m (10%)[0m  [37m0 (0%)[0m
+				[36m[0m  [32mmemory[0m             [35m70Mi (3%)[0m   [37m170Mi (8%)[0m
+				[33mEvents[0m:              [33m<none>[0m
+			`),
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -68,7 +143,7 @@ func Test_DescribePrinter_Print(t *testing.T) {
 			t.Parallel()
 			r := strings.NewReader(tt.input)
 			var w bytes.Buffer
-			printer := DescribePrinter{DarkBackground: tt.darkBackground}
+			printer := DescribePrinter{DarkBackground: tt.darkBackground, TablePrinter: tt.tablePrinter}
 			printer.Print(r, &w)
 			testutil.MustEqual(t, tt.expected, w.String())
 		})

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -60,7 +60,10 @@ func (kp *KubectlOutputColoredPrinter) Print(r io.Reader, w io.Writer) {
 		}
 
 	case kubectl.Describe:
-		printer = &DescribePrinter{DarkBackground: kp.DarkBackground}
+		printer = &DescribePrinter{
+			DarkBackground: kp.DarkBackground,
+			TablePrinter:   NewTablePrinter(false, kp.DarkBackground, nil),
+		}
 	}
 
 	printer.Print(r, w)

--- a/printer/table.go
+++ b/printer/table.go
@@ -39,7 +39,7 @@ func (tp *TablePrinter) Print(r io.Reader, w io.Writer) {
 			continue
 		}
 
-		tp.printLineAsTableFormat(w, line, getColorsByBackground(tp.DarkBackground), tp.ColorDeciderFn)
+		tp.printLineAsTableFormat(w, line, getColorsByBackground(tp.DarkBackground))
 	}
 }
 
@@ -68,7 +68,7 @@ func (tp *TablePrinter) isHeader() bool {
 // If the function returned ok=true, then returned color will be used for the column.
 // If it returned ok=false, then default configurated color will be used.
 // If deciderFn is null, then this function uses the default configurated color.
-func (tp *TablePrinter) printLineAsTableFormat(w io.Writer, line string, colorsPreset []color.Color, deciderFn func(index int, column string) (color.Color, bool)) {
+func (tp *TablePrinter) printLineAsTableFormat(w io.Writer, line string, colorsPreset []color.Color) {
 	columns := spaces.Split(line, -1)
 	spacesIndices := spaces.FindAllStringIndex(line, -1)
 
@@ -84,8 +84,8 @@ func (tp *TablePrinter) printLineAsTableFormat(w io.Writer, line string, colorsP
 		}
 
 		c := tp.decideColorForTable(index, colorsPreset)
-		if deciderFn != nil {
-			if cc, ok := deciderFn(i, column); ok {
+		if tp.ColorDeciderFn != nil {
+			if cc, ok := tp.ColorDeciderFn(i, column); ok {
 				c = cc // prior injected deciderFn result
 			}
 		}


### PR DESCRIPTION
## WHAT
Handle table in kubectl describe

## WHY

Originally, it looked something like this:
![image](https://user-images.githubusercontent.com/60682957/96357856-d50be000-113b-11eb-95de-0d8c33346fa4.png)

Now:

![image](https://user-images.githubusercontent.com/60682957/96357861-e0f7a200-113b-11eb-9c69-b06bbe897f64.png)


## Related issue (if exists)

This will fix a part of https://github.com/dty1er/kubecolor/issues/15