### PR TITLE
Support kubectl api-versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Not in the list: Won't be supported because it's not READ operation
 - [ ] kubectl explain
 - [ ] kubectl logs
 - [x] kubectl api-rsources
-- [ ] kubectl api-versions
+- [x] kubectl api-versions
 - [ ] kubectl version
 
 ### format options

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -27,6 +27,9 @@ func (kp *KubectlOutputColoredPrinter) Print(r io.Reader, w io.Writer) {
 	case kubectl.Top, kubectl.APIResources:
 		printer = NewTablePrinter(withHeader, kp.DarkBackground, nil)
 
+	case kubectl.APIVersions:
+		printer = NewTablePrinter(false, kp.DarkBackground, nil) // api-versions always doesn't have header
+
 	case kubectl.Get:
 		switch {
 		case kp.SubcommandInfo.FormatOption == kubectl.None, kp.SubcommandInfo.FormatOption == kubectl.Wide:

--- a/printer/kubectl_output_colored_printer_test.go
+++ b/printer/kubectl_output_colored_printer_test.go
@@ -265,6 +265,50 @@ func Test_KubectlOutputColoredPrinter_Print(t *testing.T) {
 				[33mAnnotations[0m:  [33m<none>[0m
 			`),
 		},
+		{
+			name:           "kubectl api-versions",
+			darkBackground: true,
+			subcommandInfo: &kubectl.SubcommandInfo{
+				Subcommand: kubectl.APIVersions,
+			},
+			input: testutil.NewHereDoc(`
+				acme.cert-manager.io/v1alpha2
+				admissionregistration.k8s.io/v1beta1
+				apiextensions.k8s.io/v1beta1
+				apiregistration.k8s.io/v1
+				apiregistration.k8s.io/v1beta1
+				apps/v1
+				apps/v1beta1
+				apps/v1beta2
+				authentication.k8s.io/v1
+				authentication.k8s.io/v1beta1
+				authorization.k8s.io/v1
+				authorization.k8s.io/v1beta1
+				autoscaling/v1
+				autoscaling/v2beta1
+				autoscaling/v2beta2
+				batch/v1
+				batch/v1beta1`),
+			expected: testutil.NewHereDoc(`
+				[36macme.cert-manager.io/v1alpha2[0m
+				[36madmissionregistration.k8s.io/v1beta1[0m
+				[36mapiextensions.k8s.io/v1beta1[0m
+				[36mapiregistration.k8s.io/v1[0m
+				[36mapiregistration.k8s.io/v1beta1[0m
+				[36mapps/v1[0m
+				[36mapps/v1beta1[0m
+				[36mapps/v1beta2[0m
+				[36mauthentication.k8s.io/v1[0m
+				[36mauthentication.k8s.io/v1beta1[0m
+				[36mauthorization.k8s.io/v1[0m
+				[36mauthorization.k8s.io/v1beta1[0m
+				[36mautoscaling/v1[0m
+				[36mautoscaling/v2beta1[0m
+				[36mautoscaling/v2beta2[0m
+				[36mbatch/v1[0m
+				[36mbatch/v1beta1[0m
+			`),
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
## WHAT

Support kubectl api-versions

## WHY

It's read command and should be supported
