### PR TITLE
README: More defensive alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ you can use kubecolor as a complete alternative of kubectl. It means you can wri
 ```sh
 alias kubectl="kubecolor"
 ```
+If you use your .bash_profile on more than one computer (e.g. synced via git) that might not all have `kubecolor` 
+installed, you can avoid breaking `kubectl` like so: 
+
+```sh
+command -v kubecolor >/dev/null 2>&1 && alias kubectl="kubecolor"
+```
 
 kubecolor is developed to colorize the output of only READ commands (get, describe...). 
 So if the given subcommand was for WRITE operations (apply, edit...), it doesn't give great decorations on it.


### PR DESCRIPTION
## WHAT
Creates alias more defensively

## WHY

Will not break kubectl if "kubecolor" command is not on PATH.

## Related issue (if exists)
