### PR TITLE
Build binary for Linux ppc64le

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,7 @@ builds:
     - linux
   goarch:
     - amd64
+    - ppc64le
 
 archives:
 - builds:


### PR DESCRIPTION
## WHAT

Produce binary for Linux ppc64le

## WHY

Because many people are using k8s that runs on IBM POWER9 CPU

## Related issue (if exists)

N/A