### PR TITLE
Add run in unsupported command because it accepts tty

### DIFF
--- a/command/subcommand.go
+++ b/command/subcommand.go
@@ -53,6 +53,7 @@ func isColoringSupported(sc kubectl.Subcommand) bool {
 		kubectl.Proxy,
 		kubectl.Plugin,
 		kubectl.Wait,
+		kubectl.Run,
 	}
 
 	for _, u := range unsupported {


### PR DESCRIPTION
## WHAT

Unsupport `kubectl run` 

## WHY

`kubectl run` accepts `-it` , just like `docker exec -it`, which attaches stdin to the pod's stdin.

## Related issue (if exists)

https://github.com/dty1er/kubecolor/issues/46