### PR TITLE
inherit exitcode

### DIFF
--- a/cmd/kubecolor/main.go
+++ b/cmd/kubecolor/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"os"
 
 	"github.com/dty1er/kubecolor/command"
@@ -10,7 +10,10 @@ import (
 func main() {
 	err := command.Run(os.Args[1:])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
+		var ke *command.KubectlError
+		if errors.As(err, &ke) {
+			os.Exit(ke.ExitCode)
+		}
 		os.Exit(1)
 	}
 }

--- a/command/errors.go
+++ b/command/errors.go
@@ -1,0 +1,11 @@
+package command
+
+import "fmt"
+
+type KubectlError struct {
+	ExitCode int
+}
+
+func (ke *KubectlError) Error() string {
+	return fmt.Sprintf("kubectl error: %d", ke.ExitCode)
+}

--- a/command/errors_test.go
+++ b/command/errors_test.go
@@ -1,0 +1,10 @@
+package command
+
+import "testing"
+
+func TestKubectlError(t *testing.T) {
+	e := &KubectlError{1}
+	if e.Error() != "kubectl error 1" {
+		t.Errorf("unexpected error")
+	}
+}

--- a/command/errors_test.go
+++ b/command/errors_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestKubectlError(t *testing.T) {
 	e := &KubectlError{1}
-	if e.Error() != "kubectl error 1" {
+	if e.Error() != "kubectl error: 1" {
 		t.Errorf("unexpected error")
 	}
 }

--- a/command/runner.go
+++ b/command/runner.go
@@ -58,7 +58,10 @@ func Run(args []string) error {
 			return err
 		}
 
-		cmd.Wait()
+		// inherit the kubectl exit code
+		if err := cmd.Wait(); err != nil {
+			return fmt.Errorf("%w", &KubectlError{ExitCode: cmd.ProcessState.ExitCode()})
+		}
 		return nil
 	}
 

--- a/command/runner.go
+++ b/command/runner.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -93,7 +94,11 @@ func Run(args []string) error {
 	}()
 
 	wg.Wait()
-	cmd.Wait()
+
+	// inherit the kubectl exit code
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("%w", &KubectlError{ExitCode: cmd.ProcessState.ExitCode()})
+	}
 
 	return nil
 }


### PR DESCRIPTION
## WHAT

Exit kubecolor with the code kubectl returned

## WHY

kubecolor is supposed to be an alternative to kubectl, so it should not lose exit code information.

## Related issue (if exists)
https://github.com/dty1er/kubecolor/issues/41