### PR TITLE
feat: add fish shell completions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,21 +140,16 @@ Fish completion is officially unsupported by `kubectl`, so it is unsupported by 
 However, there are 2 ways we can make them work. Please keep in mind these are a kind of "hack" and not officially supported.
 
 1. Use [evanlucas/fish-kubectl-completions](https://github.com/evanlucas/fish-kubectl-completions) with `kubecolor`
-
-  1. Install `kubectl` completions (https://github.com/evanlucas/fish-kubectl-completions):
-
-    ```shell
-    fisher install evanlucas/fish-kubectl-completions
-    ```
-
-  2. Add the following function to your `config.fish` file:
-
-    ```shell
-    function kubectl
-      kubecolor $argv
-    end
-    ```
-
+   1. Install `kubectl` completions (https://github.com/evanlucas/fish-kubectl-completions):
+     ```
+     fisher install evanlucas/fish-kubectl-completions
+     ```
+   2. Add the following function to your `config.fish` file:
+     ```
+     function kubectl
+       kubecolor $argv
+     end
+     ```
 2. Use [awinecki/fish-kubecolor-completions](https://github.com/awinecki/fish-kubecolor-completions)
 
   The first way will override `kubectl` command. If you wish to preserve both `kubectl` and `kubecolor` with completions, you need to copy [evanlucas/fish-kubectl-completions](https://github.com/evanlucas/fish-kubectl-completions) for the `kubecolor` command.

--- a/README.md
+++ b/README.md
@@ -129,23 +129,27 @@ compdef kubecolor=kubectl
 
 #### fish
 
-For fish, you can achieve completions for `kubecolor` in two steps:
+Fish completion is officially unsupported by `kubectl`, so it is unsupported by `kubecolor` as well.
 
-1. Install `kubectl` completions (https://github.com/evanlucas/fish-kubectl-completions)
+However, there are 2 ways we can make them work. Please keep in mind these are a kind of "hack" and not officially supported.
 
-   ```shell
-   fisher install evanlucas/fish-kubectl-completions
-   ```
+- Use [evanlucas/fish-kubectl-completions](https://github.com/evanlucas/fish-kubectl-completions) with kubecolor:
 
-2. Add the following function to your `config.fish` file:
+  1. Install `kubectl` completions (https://github.com/evanlucas/fish-kubectl-completions):
 
-   ```shell
-   function kubectl
-     kubecolor $argv
-   end
-   ```
+    ```shell
+    fisher install evanlucas/fish-kubectl-completions
+    ```
 
-**NOTE:** This will override `kubectl` command. If you wish to preserve both `kubectl` and `kubecolor` with completions, you need to copy completions for `kubecolor` command (e.g. https://github.com/awinecki/fish-kubecolor-completions).
+  2. Add the following function to your `config.fish` file:
+
+    ```shell
+    function kubectl
+      kubecolor $argv
+    end
+    ```
+
+- Duplicate `kubectl` fish completions and rename to `kubecolor` (example repo: https://github.com/awinecki/fish-kubecolor-completions). As the first method overrides your `kubectl`, this is a way to have both on your system, including completions.
 
 ### Specify what command to execute as kubectl
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,24 @@ compdef kubecolor=kubectl
 
 #### fish
 
-Fish completion is unsupported because fish completion is officially not supported by kubectl.
+Fish completion for `kubectl` is not officially not supported.
+
+For a workaround, you can use an unofficial completion set (**WARNING: long-term support not guaranteed**):
+
+```shell
+fisher install awinecki/fish-kubecolor-completions
+```
+
+or
+
+```shell
+mkdir -p ~/.config/fish/completions
+cd ~/.config/fish
+git clone https://github.com/awinecki/fish-kubecolor-completions
+ln -s ../fish-kubecolor-completions/completions/kubecolor.fish completions/
+```
+
+For an alias, add `alias kc=kubecolor` to your `config.fish` file.
 
 ### Specify what command to execute as kubectl
 

--- a/README.md
+++ b/README.md
@@ -129,24 +129,23 @@ compdef kubecolor=kubectl
 
 #### fish
 
-Fish completion for `kubectl` is not officially not supported.
+For fish, you can achieve completions for `kubecolor` in two steps:
 
-For a workaround, you can use an unofficial completion set (**WARNING: long-term support not guaranteed**):
+1. Install `kubectl` completions (https://github.com/evanlucas/fish-kubectl-completions)
 
-```shell
-fisher install awinecki/fish-kubecolor-completions
-```
+   ```shell
+   fisher install evanlucas/fish-kubectl-completions
+   ```
 
-or
+2. Add the following function to your `config.fish` file:
 
-```shell
-mkdir -p ~/.config/fish/completions
-cd ~/.config/fish
-git clone https://github.com/awinecki/fish-kubecolor-completions
-ln -s ../fish-kubecolor-completions/completions/kubecolor.fish completions/
-```
+   ```shell
+   function kubectl
+     kubecolor $argv
+   end
+   ```
 
-For an alias, add `alias kc=kubecolor` to your `config.fish` file.
+**NOTE:** This will override `kubectl` command. If you wish to preserve both `kubectl` and `kubecolor` with completions, you need to copy completions for `kubecolor` command (e.g. https://github.com/awinecki/fish-kubecolor-completions).
 
 ### Specify what command to execute as kubectl
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Fish completion is officially unsupported by `kubectl`, so it is unsupported by 
 
 However, there are 2 ways we can make them work. Please keep in mind these are a kind of "hack" and not officially supported.
 
-- Use [evanlucas/fish-kubectl-completions](https://github.com/evanlucas/fish-kubectl-completions) with kubecolor:
+1. Use [evanlucas/fish-kubectl-completions](https://github.com/evanlucas/fish-kubectl-completions) with `kubecolor`
 
   1. Install `kubectl` completions (https://github.com/evanlucas/fish-kubectl-completions):
 
@@ -149,7 +149,12 @@ However, there are 2 ways we can make them work. Please keep in mind these are a
     end
     ```
 
-- Duplicate `kubectl` fish completions and rename to `kubecolor` (example repo: https://github.com/awinecki/fish-kubecolor-completions). As the first method overrides your `kubectl`, this is a way to have both on your system, including completions.
+2. Use [awinecki/fish-kubecolor-completions](https://github.com/awinecki/fish-kubecolor-completions)
+
+  The first way will override `kubectl` command. If you wish to preserve both `kubectl` and `kubecolor` with completions, you need to copy [evanlucas/fish-kubectl-completions](https://github.com/evanlucas/fish-kubectl-completions) for the `kubecolor` command.
+
+  For this purpose, you can use [awinecki/fish-kubecolor-completions](https://github.com/awinecki/fish-kubecolor-completions).
+
 
 ### Specify what command to execute as kubectl
 

--- a/README.md
+++ b/README.md
@@ -139,22 +139,23 @@ Fish completion is officially unsupported by `kubectl`, so it is unsupported by 
 
 However, there are 2 ways we can make them work. Please keep in mind these are a kind of "hack" and not officially supported.
 
-1. Use [evanlucas/fish-kubectl-completions](https://github.com/evanlucas/fish-kubectl-completions) with `kubecolor`
-   1. Install `kubectl` completions (https://github.com/evanlucas/fish-kubectl-completions):
-     ```
-     fisher install evanlucas/fish-kubectl-completions
-     ```
-   2. Add the following function to your `config.fish` file:
-     ```
-     function kubectl
-       kubecolor $argv
-     end
-     ```
+1. Use [evanlucas/fish-kubectl-completions](https://github.com/evanlucas/fish-kubectl-completions) with `kubecolor`:
+
+   * Install `kubectl` completions (https://github.com/evanlucas/fish-kubectl-completions):
+      ```
+      fisher install evanlucas/fish-kubectl-completions
+      ```
+   * Add the following function to your `config.fish` file:
+      ```
+      function kubectl
+        kubecolor $argv
+      end
+      ```
 2. Use [awinecki/fish-kubecolor-completions](https://github.com/awinecki/fish-kubecolor-completions)
 
-  The first way will override `kubectl` command. If you wish to preserve both `kubectl` and `kubecolor` with completions, you need to copy [evanlucas/fish-kubectl-completions](https://github.com/evanlucas/fish-kubectl-completions) for the `kubecolor` command.
+   The first way will override `kubectl` command. If you wish to preserve both `kubectl` and `kubecolor` with completions, you need to copy [evanlucas/fish-kubectl-completions](https://github.com/evanlucas/fish-kubectl-completions) for the `kubecolor` command.
 
-  For this purpose, you can use [awinecki/fish-kubecolor-completions](https://github.com/awinecki/fish-kubecolor-completions).
+   For this purpose, you can use [awinecki/fish-kubecolor-completions](https://github.com/awinecki/fish-kubecolor-completions).
 
 
 ### Specify what command to execute as kubectl


### PR DESCRIPTION
Hello; such a great project! I'm just learning k8s, and I like my CLI UI to be clean and readable.

As I've been using fish for a while now, I was sad to discover I can't use `kubecolor` with proper completions with fish. Completions are necessary to me for learning, so I tried to make it work.

As I'm no expert when it comes to hacking `fish`, I just took @evanlucas (thx ! 🙏 ) completions, and replaced all `kubectl` with `kubecolor`. It's ugly, but it works.

@evanlucas, perhaps you could guide me how to do it in a cleaner way. I know little about `go`, and seems you're using it to generate these completions. Worst case, I could just set up a github action that periodically fetches your `kubectl` completions and builds `kubecolor` ones from that.