### PR TITLE
fix test manifests namespaces

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx
+  namespace: kubecolor
 spec:
   replicas: 3
   selector:

--- a/manifests/replicaset.yaml
+++ b/manifests/replicaset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: nginx
+  namespace: kubecolor
 spec:
   replicas: 3
   selector:

--- a/manifests/resource_quota.yaml
+++ b/manifests/resource_quota.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: mem-cpu-quota
+  namespace: kubecolor
 spec:
   hard:
     requests.cpu: "1"


### PR DESCRIPTION
## WHAT

Specify namespace in test manifest files

## WHY

"kubecolor" namespace is intended to be a test namespace for kubecolor, so other files should target it but was missing.