### PR TITLE
fix bug: leading dash is unintendedly removed in yaml printer

### DIFF
--- a/manifests/pod.yaml
+++ b/manifests/pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: kubecolor
+spec:
+  containers:
+    - name: main
+      image: remrain/tiny-hello
+      args:
+      - -test

--- a/printer/yaml.go
+++ b/printer/yaml.go
@@ -29,7 +29,6 @@ func (yp *YamlPrinter) printLineAsYamlFormat(line string, w io.Writer, dark bool
 	trimmedLine := strings.TrimLeft(line, " ")
 
 	if yp.inString {
-		// fmt.Println(trimmedLine)
 		// if inString is true, the line must be a part of a string which is broken into several lines
 		fmt.Fprintf(w, "%s%s\n", indent, yp.toColorizedStringValue(trimmedLine, dark))
 		yp.inString = !yp.isStringClosed(trimmedLine)
@@ -59,8 +58,8 @@ func (yp *YamlPrinter) printLineAsYamlFormat(line string, w io.Writer, dark bool
 func (yp *YamlPrinter) toColorizedYamlKey(key string, indentCnt, basicWidth int, dark bool) string {
 	hasColon := strings.HasSuffix(key, ":")
 	hasLeadingDash := strings.HasPrefix(key, "- ")
-	key = strings.TrimRight(key, ":")
-	key = strings.TrimLeft(key, "- ")
+	key = strings.TrimSuffix(key, ":")
+	key = strings.TrimPrefix(key, "- ")
 
 	format := "%s"
 	if hasColon {
@@ -81,10 +80,10 @@ func (yp *YamlPrinter) toColorizedYamlValue(value string, dark bool) string {
 	}
 
 	hasLeadingDash := strings.HasPrefix(value, "- ")
-	value = strings.TrimLeft(value, "- ")
+	value = strings.TrimPrefix(value, "- ")
 
 	isDoubleQuoted := strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`)
-	trimmedValue := strings.TrimRight(strings.TrimLeft(value, `"`), `"`)
+	trimmedValue := strings.TrimSuffix(strings.TrimPrefix(value, `"`), `"`)
 
 	var format string
 	switch {

--- a/printer/yaml_test.go
+++ b/printer/yaml_test.go
@@ -79,6 +79,29 @@ func Test_YamlPrinter_Print(t *testing.T) {
 			`),
 		},
 		{
+			name:           "a value contains dash",
+			darkBackground: true,
+			input: testutil.NewHereDoc(`
+				apiVersion: v1
+				items:
+				- apiVersion: v1
+				  key:
+				  - key2: 415
+				    key3: true
+				  key4:
+				    key: -val`),
+			expected: testutil.NewHereDoc(`
+				[33mapiVersion[0m: [36mv1[0m
+				[33mitems[0m:
+				- [37mapiVersion[0m: [36mv1[0m
+				  [37mkey[0m:
+				  - [33mkey2[0m: [35m415[0m
+				    [33mkey3[0m: [32mtrue[0m
+				  [37mkey4[0m:
+				    [33mkey[0m: [36m-val[0m
+			`),
+		},
+		{
 			name:           "a long string which is broken into several lines can be colored",
 			darkBackground: true,
 			input: testutil.NewHereDoc(`


### PR DESCRIPTION
## WHAT
The same as title

## Related issue (if exists)
https://github.com/dty1er/kubecolor/issues/55