### PR TITLE
enable to print out kubecolor version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,9 @@ builds:
 - id: kubecolor
   main: ./cmd/kubecolor/main.go
   binary: kubecolor
+  ldflags:
+    - -s -w -trimpath
+    - -X main.Version={{.Version}}
   goos:
     - windows
     - darwin

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ alias kubectl="kubecolor"
 
 ### Flags
 
+* `--kubecolor-version`
+
+Prints the version of kubecolor (not kubectl one).
+
 * `--plain`
 
 When you don't want to colorize output, you can specify `--plain`. Kubecolor understands this option and

--- a/cmd/kubecolor/main.go
+++ b/cmd/kubecolor/main.go
@@ -7,8 +7,11 @@ import (
 	"github.com/dty1er/kubecolor/command"
 )
 
+// this is overridden on build time by GoReleaser
+var Version string = "unset"
+
 func main() {
-	err := command.Run(os.Args[1:])
+	err := command.Run(os.Args[1:], Version)
 	if err != nil {
 		var ke *command.KubectlError
 		if errors.As(err, &ke) {

--- a/command/config.go
+++ b/command/config.go
@@ -3,16 +3,18 @@ package command
 import "os"
 
 type KubecolorConfig struct {
-	Plain          bool
-	DarkBackground bool
-	ForceColor     bool
-	KubectlCmd     string
+	Plain                bool
+	DarkBackground       bool
+	ForceColor           bool
+	ShowKubecolorVersion bool
+	KubectlCmd           string
 }
 
 func ResolveConfig(args []string) ([]string, *KubecolorConfig) {
 	args, plainFlagFound := findAndRemoveBoolFlagIfExists(args, "--plain")
 	args, lightBackgroundFlagFound := findAndRemoveBoolFlagIfExists(args, "--light-background")
 	args, forceColorFlagFound := findAndRemoveBoolFlagIfExists(args, "--force-colors")
+	args, kubecolorVersionFlagFound := findAndRemoveBoolFlagIfExists(args, "--kubecolor-version")
 
 	darkBackground := !lightBackgroundFlagFound
 
@@ -22,10 +24,11 @@ func ResolveConfig(args []string) ([]string, *KubecolorConfig) {
 	}
 
 	return args, &KubecolorConfig{
-		Plain:          plainFlagFound,
-		DarkBackground: darkBackground,
-		ForceColor:     forceColorFlagFound,
-		KubectlCmd:     kubectlCmd,
+		Plain:                plainFlagFound,
+		DarkBackground:       darkBackground,
+		ForceColor:           forceColorFlagFound,
+		ShowKubecolorVersion: kubecolorVersionFlagFound,
+		KubectlCmd:           kubectlCmd,
 	}
 }
 

--- a/command/runner.go
+++ b/command/runner.go
@@ -43,9 +43,14 @@ var getPrinters = func(subcommandInfo *kubectl.SubcommandInfo, darkBackground bo
 	}
 }
 
-func Run(args []string) error {
+func Run(args []string, version string) error {
 	args, config := ResolveConfig(args)
 	shouldColorize, subcommandInfo := ResolveSubcommand(args, config)
+
+	if config.ShowKubecolorVersion {
+		fmt.Fprintf(os.Stdout, "%s\n", version)
+		return nil
+	}
 
 	cmd := exec.Command(config.KubectlCmd, args...)
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
## WHAT

Print kubecolor version by `kubecolor --kubecolor-version`

## WHY

To make it easy to understand if users are using the latest one

Just `--version` is confusing with kubectl's version.