### PR TITLE
colorize apply result by the action

### DIFF
--- a/printer/kubectl_apply.go
+++ b/printer/kubectl_apply.go
@@ -22,29 +22,64 @@ func (ap *ApplyPrinter) Print(r io.Reader, w io.Writer) {
 		applyActionCreated    = "created"
 		applyActionConfigured = "configured"
 		applyActionUnchanged  = "unchanged"
+
+		dryRunStr = "(dry run)"
 	)
 
-	colors := map[string]color.Color{
+	darkColors := map[string]color.Color{
 		applyActionCreated:    color.Green,
 		applyActionConfigured: color.Yellow,
 		applyActionUnchanged:  color.Magenta,
+		dryRunStr:             color.Cyan,
+	}
+	lightColors := map[string]color.Color{
+		applyActionCreated:    color.Green,
+		applyActionConfigured: color.Yellow,
+		applyActionUnchanged:  color.Magenta,
+		dryRunStr:             color.Blue,
 	}
 
-	colorize := func(line, action string, wr io.Writer) {
+	colors := func(action string, dark bool) color.Color {
+		if dark {
+			return darkColors[action]
+		}
+		return lightColors[action]
+	}
+
+	colorize := func(line, action string, dryRun bool, wr io.Writer) {
+		if dryRun {
+			arg := strings.TrimSuffix(line, fmt.Sprintf(" %s %s", action, dryRunStr))
+			fmt.Fprintf(w, "%s %s %s\n",
+				arg,
+				color.Apply(action, colors(action, ap.DarkBackground)),
+				color.Apply(dryRunStr, colors(dryRunStr, ap.DarkBackground)),
+			)
+			return
+		}
+
 		arg := strings.TrimSuffix(line, " "+action)
-		fmt.Fprintf(w, "%s %s\n", arg, color.Apply(action, colors[action]))
+		fmt.Fprintf(w, "%s %s\n", arg, color.Apply(action, colors(action, ap.DarkBackground)))
 	}
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
 		switch {
+		// on dry run cases, it shows "xxx created (dry run)"
+		case strings.HasSuffix(line, fmt.Sprintf(" %s %s", applyActionCreated, dryRunStr)):
+			colorize(line, applyActionCreated, true, w)
+		case strings.HasSuffix(line, fmt.Sprintf(" %s %s", applyActionConfigured, dryRunStr)):
+			colorize(line, applyActionConfigured, true, w)
+		case strings.HasSuffix(line, fmt.Sprintf(" %s %s", applyActionUnchanged, dryRunStr)):
+			colorize(line, applyActionUnchanged, true, w)
+
+		// not dry run cases, it shows "xxx created"
 		case strings.HasSuffix(line, " "+applyActionCreated):
-			colorize(line, applyActionCreated, w)
+			colorize(line, applyActionCreated, false, w)
 		case strings.HasSuffix(line, " "+applyActionConfigured):
-			colorize(line, applyActionConfigured, w)
+			colorize(line, applyActionConfigured, false, w)
 		case strings.HasSuffix(line, " "+applyActionUnchanged):
-			colorize(line, applyActionUnchanged, w)
+			colorize(line, applyActionUnchanged, false, w)
 		default:
 			fmt.Fprintf(w, "%s\n", color.Apply(line, color.Green))
 		}

--- a/printer/kubectl_apply.go
+++ b/printer/kubectl_apply.go
@@ -1,0 +1,52 @@
+package printer
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/dty1er/kubecolor/color"
+)
+
+type ApplyPrinter struct {
+	DarkBackground bool
+}
+
+// kubectl apply
+// deployment.apps/foo unchanged
+// deployment.apps/bar created
+// deployment.apps/quux configured
+func (ap *ApplyPrinter) Print(r io.Reader, w io.Writer) {
+	const (
+		applyActionCreated    = "created"
+		applyActionConfigured = "configured"
+		applyActionUnchanged  = "unchanged"
+	)
+
+	colors := map[string]color.Color{
+		applyActionCreated:    color.Green,
+		applyActionConfigured: color.Yellow,
+		applyActionUnchanged:  color.Magenta,
+	}
+
+	colorize := func(line, action string, wr io.Writer) {
+		arg := strings.TrimSuffix(line, " "+action)
+		fmt.Fprintf(w, "%s %s\n", arg, color.Apply(action, colors[action]))
+	}
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasSuffix(line, " "+applyActionCreated):
+			colorize(line, applyActionCreated, w)
+		case strings.HasSuffix(line, " "+applyActionConfigured):
+			colorize(line, applyActionConfigured, w)
+		case strings.HasSuffix(line, " "+applyActionUnchanged):
+			colorize(line, applyActionUnchanged, w)
+		default:
+			fmt.Fprintf(w, "%s\n", color.Apply(line, color.Green))
+		}
+	}
+}

--- a/printer/kubectl_apply_test.go
+++ b/printer/kubectl_apply_test.go
@@ -1,0 +1,67 @@
+package printer
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/dty1er/kubecolor/testutil"
+)
+
+func Test_ApplyPrinter_Print(t *testing.T) {
+	tests := []struct {
+		name           string
+		darkBackground bool
+		tablePrinter   *TablePrinter
+		input          string
+		expected       string
+	}{
+		{
+			name:           "created",
+			darkBackground: true,
+			input: testutil.NewHereDoc(`
+				deployment.apps/foo created`),
+			expected: testutil.NewHereDoc(`
+				deployment.apps/foo [32mcreated[0m
+			`),
+		},
+		{
+			name:           "configured",
+			darkBackground: true,
+			input: testutil.NewHereDoc(`
+				deployment.apps/foo configured`),
+			expected: testutil.NewHereDoc(`
+				deployment.apps/foo [33mconfigured[0m
+			`),
+		},
+		{
+			name:           "unchanged",
+			darkBackground: true,
+			input: testutil.NewHereDoc(`
+				deployment.apps/foo unchanged`),
+			expected: testutil.NewHereDoc(`
+				deployment.apps/foo [35munchanged[0m
+			`),
+		},
+		{
+			name:           "something else. This likely won't happen but fallbacks here just in case.",
+			darkBackground: true,
+			input: testutil.NewHereDoc(`
+				deployment.apps/foo bar`),
+			expected: testutil.NewHereDoc(`
+				[32mdeployment.apps/foo bar[0m
+			`),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := strings.NewReader(tt.input)
+			var w bytes.Buffer
+			printer := ApplyPrinter{DarkBackground: tt.darkBackground}
+			printer.Print(r, &w)
+			testutil.MustEqual(t, tt.expected, w.String())
+		})
+	}
+}

--- a/printer/kubectl_apply_test.go
+++ b/printer/kubectl_apply_test.go
@@ -44,6 +44,15 @@ func Test_ApplyPrinter_Print(t *testing.T) {
 			`),
 		},
 		{
+			name:           "dry run",
+			darkBackground: true,
+			input: testutil.NewHereDoc(`
+				deployment.apps/foo unchanged (dry run)`),
+			expected: testutil.NewHereDoc(`
+				deployment.apps/foo [35munchanged[0m [36m(dry run)[0m
+			`),
+		},
+		{
 			name:           "something else. This likely won't happen but fallbacks here just in case.",
 			darkBackground: true,
 			input: testutil.NewHereDoc(`

--- a/printer/kubectl_output_colored_printer.go
+++ b/printer/kubectl_output_colored_printer.go
@@ -99,6 +99,7 @@ func (kp *KubectlOutputColoredPrinter) Print(r io.Reader, w io.Writer) {
 		case kp.SubcommandInfo.FormatOption == kubectl.Yaml:
 			printer = &YamlPrinter{DarkBackground: kp.DarkBackground}
 		default:
+			printer = &ApplyPrinter{DarkBackground: kp.DarkBackground}
 		}
 	}
 


### PR DESCRIPTION
## WHAT

Colorize `kubectl apply` result by its action.

### Before this PR
![スクリーンショット 2021-04-27 212349](https://user-images.githubusercontent.com/60682957/116240555-0e836080-a708-11eb-8f6d-7b1c4cf4deee.png)

### After this PR

"unchanged" and "configured"

![スクリーンショット 2021-04-27 212402](https://user-images.githubusercontent.com/60682957/116240543-0a574300-a708-11eb-9b92-dd677fe04a89.png)

"created"

![スクリーンショット 2021-04-27 211631](https://user-images.githubusercontent.com/60682957/116240607-1cd17c80-a708-11eb-98cf-7227d9c8df33.png)

## Related issue (if exists)

https://github.com/dty1er/kubecolor/issues/56
