### PR TITLE
support arm64 arch for M1 mac

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
     - darwin
     - linux
   goarch:
+    - arm64
     - amd64
     - ppc64le
 


### PR DESCRIPTION
## Related issue (if exists)
https://github.com/dty1er/kubecolor/issues/63