### PR TITLE
Avoid "krew version" crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ When you don't set `KUBECTL_COMMAND`, then `kubectl` is used by default.
 Because kubecolor internally calls `kubectl` command, if you are using unsupported kubectl version, it's also not supported by kubecolor.
 Kubernetes version support policy can be found in [official doc](https://kubernetes.io/docs/setup/release/version-skew-policy/).
 
+## Krew
+
+[Krew](https://krew.sigs.k8s.io/) is unsupported for now.
+
 ## Contributions
 
 Always welcome. Just opening an issue should be also greatful.

--- a/command/runner.go
+++ b/command/runner.go
@@ -56,7 +56,8 @@ func Run(args []string, version string) error {
 	cmd.Stdin = os.Stdin
 
 	// when should not colorize, just run command and return
-	if !shouldColorize {
+	// TODO: right now, krew is unsupported by kubecolor but it should be.
+	if !shouldColorize || subcommandInfo.IsKrew {
 		cmd.Stdout = Stdout
 		cmd.Stderr = Stderr
 		if err := cmd.Start(); err != nil {

--- a/command/subcommand.go
+++ b/command/subcommand.go
@@ -16,6 +16,10 @@ func ResolveSubcommand(args []string, config *KubecolorConfig) (bool, *kubectl.S
 	// subcommandFound becomes false when subcommand is not found; e.g. "kubecolor --help"
 	subcommandInfo, subcommandFound := kubectl.InspectSubcommandInfo(args)
 
+	if subcommandInfo.IsKrew {
+		return false, subcommandInfo
+	}
+
 	// if --plain found, it does not colorize
 	if config.Plain {
 		return false, subcommandInfo

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -12,6 +12,8 @@ type SubcommandInfo struct {
 	Help         bool
 	Recursive    bool
 	Short        bool
+
+	IsKrew bool
 }
 
 type FormatOption int
@@ -194,7 +196,21 @@ func CollectCommandlineOptions(args []string, info *SubcommandInfo) {
 }
 
 func InspectSubcommandInfo(args []string) (*SubcommandInfo, bool) {
+	// TODO: support krew
+	contains := func(s []string, e string) bool {
+		for _, a := range s {
+			if a == e {
+				return true
+			}
+		}
+		return false
+	}
 	ret := &SubcommandInfo{}
+
+	if contains(args, "krew") {
+		return &SubcommandInfo{IsKrew: true}, false
+	}
+
 	CollectCommandlineOptions(args, ret)
 
 	for i := range args {

--- a/kubectl/subcommand_test.go
+++ b/kubectl/subcommand_test.go
@@ -62,6 +62,8 @@ func TestInspectSubcommandInfo(t *testing.T) {
 
 		{"apply", &SubcommandInfo{Subcommand: Apply}, true},
 
+		{"krew version", &SubcommandInfo{IsKrew: true}, false},
+
 		{"", &SubcommandInfo{}, false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## WHAT

When subcomand is krew, it does not colorize.

## WHY

To avoid crash. see the related issue.

## Note

kubectl can extend itself by writing [plugin](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/). It means, kubectl can receive arbitrary subcommand. Because kubecolor is intended to be an alternative to kubectl, it must not panic on such "unknown" subcommands.

Eventually we will implement something like below:

* kubecolor should support kubectl official subcommand (e.g. get, describe, apply etc)
* For plugins, kubecolor does not do colorization at all, but must work as the same as kubectl (= it just prints the output out.)

We need to consider if kubecolor should support Krew because it's very "basic" plugin.

Anyway for now, this PR should be sufficient.

## Related issue (if exists)

https://github.com/dty1er/kubecolor/issues/64