### PR TITLE
handle panic

### DIFF
--- a/command/subcommand.go
+++ b/command/subcommand.go
@@ -16,10 +16,6 @@ func ResolveSubcommand(args []string, config *KubecolorConfig) (bool, *kubectl.S
 	// subcommandFound becomes false when subcommand is not found; e.g. "kubecolor --help"
 	subcommandInfo, subcommandFound := kubectl.InspectSubcommandInfo(args)
 
-	if subcommandInfo.IsKrew {
-		return false, subcommandInfo
-	}
-
 	// if --plain found, it does not colorize
 	if config.Plain {
 		return false, subcommandInfo

--- a/kubectl/subcommand.go
+++ b/kubectl/subcommand.go
@@ -195,21 +195,9 @@ func CollectCommandlineOptions(args []string, info *SubcommandInfo) {
 	}
 }
 
+// TODO: return shouldColorize = false when the given args is for plugin
 func InspectSubcommandInfo(args []string) (*SubcommandInfo, bool) {
-	// TODO: support krew
-	contains := func(s []string, e string) bool {
-		for _, a := range s {
-			if a == e {
-				return true
-			}
-		}
-		return false
-	}
 	ret := &SubcommandInfo{}
-
-	if contains(args, "krew") {
-		return &SubcommandInfo{IsKrew: true}, false
-	}
 
 	CollectCommandlineOptions(args, ret)
 

--- a/kubectl/subcommand_test.go
+++ b/kubectl/subcommand_test.go
@@ -62,8 +62,6 @@ func TestInspectSubcommandInfo(t *testing.T) {
 
 		{"apply", &SubcommandInfo{Subcommand: Apply}, true},
 
-		{"krew version", &SubcommandInfo{IsKrew: true}, false},
-
 		{"", &SubcommandInfo{}, false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## WHAT

Handle panic in Print. When `recover()`, uncolored output will be shown.

## WHY

When "kubecolor plugin_name version" or so on is specified, is should not colorize because kubecolor does not support plugins.
However, right now, kubecolor thinks "plugin_name" is a command-line option and the subcommand is "version" (= "kubectl version"). Then, VersionPrinter is called but it fail to parse then panic.

Ideally, it should understand if the given command is running plugin or not, but it seems like it is likely impossible.
This is just a workaround to "accept" mis parsing and panic.

## Related issue (if exists)
https://github.com/dty1er/kubecolor/issues/68